### PR TITLE
Allows files with date: to be parsed

### DIFF
--- a/lib/kramdown-metadata-parsers.rb
+++ b/lib/kramdown-metadata-parsers.rb
@@ -13,7 +13,7 @@ module KramdownMetadataParsers
       if source =~ /\A---/
         preamble = source[/\A---.*?^---/m]
         source   = source[preamble.size..-1]
-        metadata = YAML.load(preamble)
+        metadata = YAML.load(preamble, permitted_classes: [Date])
       end
       super(source, options)
       @root = MetadataElement.new(@root)


### PR DESCRIPTION
In newer versions of ruby, YAML.load is implemented by psych.load and it calls `safe_load` to prevent a custom class from being serialized and casing a security issue.  psych treats classes like Date in the Standard Library as "custom" and are disallowed by default.  The result is an exception when trying to load a markdown file with yaml frontmatter with a date: field.

```
/opt/homebrew/Cellar/ruby/3.4.5/lib/ruby/3.4.0/psych/class_loader.rb:99:in 'Psych::ClassLoader::Restricted#find': Tried to load unspecified class: Date (Psych::DisallowedClass)
        from /opt/homebrew/Cellar/ruby/3.4.5/lib/ruby/3.4.0/psych/class_loader.rb:28:in 'Psych::ClassLoader#load'
        from /opt/homebrew/Cellar/ruby/3.4.5/lib/ruby/3.4.0/psych/class_loader.rb:40:in 'Psych::ClassLoader#date'
        from /opt/homebrew/Cellar/ruby/3.4.5/lib/ruby/3.4.0/psych/scalar_scanner.rb:65:in 'Psych::ScalarScanner#tokenize'
        from /opt/homebrew/Cellar/ruby/3.4.5/lib/ruby/3.4.0/psych/visitors/to_ruby.rb:65:in 'Psych::Visitors::ToRuby#deserialize'
        from /opt/homebrew/Cellar/ruby/3.4.5/lib/ruby/3.4.0/psych/visitors/to_ruby.rb:129:in 'Psych::Visitors::ToRuby#visit_Psych_Nodes_Scalar'
        from /opt/homebrew/Cellar/ruby/3.4.5/lib/ruby/3.4.0/psych/visitors/visitor.rb:30:in 'Psych::Visitors::Visitor#visit'
        from /opt/homebrew/Cellar/ruby/3.4.5/lib/ruby/3.4.0/psych/visitors/visitor.rb:6:in 'Psych::Visitors::Visitor#accept'
        from /opt/homebrew/Cellar/ruby/3.4.5/lib/ruby/3.4.0/psych/visitors/to_ruby.rb:35:in 'Psych::Visitors::ToRuby#accept'
        from /opt/homebrew/Cellar/ruby/3.4.5/lib/ruby/3.4.0/psych/visitors/to_ruby.rb:346:in 'block in Psych::Visitors::ToRuby#revive_hash'
        from /opt/homebrew/Cellar/ruby/3.4.5/lib/ruby/3.4.0/psych/visitors/to_ruby.rb:344:in 'Array#each'
        from /opt/homebrew/Cellar/ruby/3.4.5/lib/ruby/3.4.0/psych/visitors/to_ruby.rb:344:in 'Enumerable#each_slice'
        from /opt/homebrew/Cellar/ruby/3.4.5/lib/ruby/3.4.0/psych/visitors/to_ruby.rb:344:in 'Psych::Visitors::ToRuby#revive_hash'
        from /opt/homebrew/Cellar/ruby/3.4.5/lib/ruby/3.4.0/psych/visitors/to_ruby.rb:168:in 'Psych::Visitors::ToRuby#visit_Psych_Nodes_Mapping'
        from /opt/homebrew/Cellar/ruby/3.4.5/lib/ruby/3.4.0/psych/visitors/visitor.rb:30:in 'Psych::Visitors::Visitor#visit'
        from /opt/homebrew/Cellar/ruby/3.4.5/lib/ruby/3.4.0/psych/visitors/visitor.rb:6:in 'Psych::Visitors::Visitor#accept'
        from /opt/homebrew/Cellar/ruby/3.4.5/lib/ruby/3.4.0/psych/visitors/to_ruby.rb:35:in 'Psych::Visitors::ToRuby#accept'
        from /opt/homebrew/Cellar/ruby/3.4.5/lib/ruby/3.4.0/psych/visitors/to_ruby.rb:319:in 'Psych::Visitors::ToRuby#visit_Psych_Nodes_Document'
        from /opt/homebrew/Cellar/ruby/3.4.5/lib/ruby/3.4.0/psych/visitors/visitor.rb:30:in 'Psych::Visitors::Visitor#visit'
        from /opt/homebrew/Cellar/ruby/3.4.5/lib/ruby/3.4.0/psych/visitors/visitor.rb:6:in 'Psych::Visitors::Visitor#accept'
        from /opt/homebrew/Cellar/ruby/3.4.5/lib/ruby/3.4.0/psych/visitors/to_ruby.rb:35:in 'Psych::Visitors::ToRuby#accept'
        from /opt/homebrew/Cellar/ruby/3.4.5/lib/ruby/3.4.0/psych.rb:336:in 'Psych.safe_load'
        from /opt/homebrew/Cellar/ruby/3.4.5/lib/ruby/3.4.0/psych.rb:371:in 'Psych.load'
        from /opt/homebrew/lib/ruby/gems/3.4.0/gems/kramdown-metadata-parsers-0.9.0/lib/kramdown-metadata-parsers.rb:16:in 'KramdownMetadataParsers::MetadataParser#initialize'
```

This patch modifies the call to YAML.load to add `permitted_classes: [Date]` as the second argument to load which enables dates to be parsed normally.